### PR TITLE
Enable syntax highlighting for Haskell

### DIFF
--- a/src/codeHighlighter.ts
+++ b/src/codeHighlighter.ts
@@ -166,4 +166,5 @@ const languages = [
 	{ name: 'dart', language: 'dart', identifiers: ['dart'], source: 'source.dart' },
 	{ name: 'handlebars', language: 'handlebars', identifiers: ['handlebars', 'hbs'], source: 'text.html.handlebars' },
 	{ name: 'markdown', language: 'markdown', identifiers: ['markdown', 'md'], source: 'text.html.markdown' },
+	{ name: 'haskell', language: 'haskell', identifiers: ['hs', 'lhs'], source: 'text.html.hs' },
 ];


### PR DESCRIPTION
This fixes #6 for the specific case of Haskell. I am not sure how to handle this in general.