### PR TITLE
Drop language lookups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "docs-view",
-	"version": "0.0.12",
+	"version": "0.0.11",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "docs-view",
-			"version": "0.0.12",
+			"version": "0.0.11",
 			"dependencies": {
 				"json5": "^2.1.3",
 				"marked": "^4.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "docs-view",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "docs-view",
-			"version": "0.0.11",
+			"version": "0.0.12",
 			"dependencies": {
 				"json5": "^2.1.3",
 				"marked": "^4.0.15",
-				"oniguruma": "^7.2.1",
-				"shiki": "^0.2.5",
-				"shiki-themes": "^0.2.5"
+				"shiki": "^0.14.1",
+				"shiki-themes": "^0.2.5",
+				"vscode-oniguruma": "^1.7.0"
 			},
 			"devDependencies": {
 				"@types/json5": "0.0.30",
@@ -568,6 +568,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/ansi-sequence-parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+			"integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ=="
 		},
 		"node_modules/ansi-styles": {
 			"version": "3.2.1",
@@ -1786,6 +1791,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -1866,14 +1876,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"node_modules/lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"dependencies": {
-				"yallist": "^3.0.2"
-			}
 		},
 		"node_modules/marked": {
 			"version": "4.0.15",
@@ -1963,11 +1965,6 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
-		"node_modules/nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2020,23 +2017,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/onigasm": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-			"integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-			"dependencies": {
-				"lru-cache": "^5.1.1"
-			}
-		},
-		"node_modules/oniguruma": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.2.1.tgz",
-			"integrity": "sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"nan": "^2.14.0"
 			}
 		},
 		"node_modules/optionator": {
@@ -2429,22 +2409,14 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.5.tgz",
-			"integrity": "sha512-TwiRLuon4m+TMZ8Qdx8VgtIj4edzxmFjW+I7IjI7xyf2b7WjTXrynuk4iDMCjdsb8zVd9oFCxqhfyNC8LGeDNQ==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+			"integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
 			"dependencies": {
-				"onigasm": "^2.2.1",
-				"shiki-languages": "^0.2.5",
-				"shiki-themes": "^0.2.5",
-				"vscode-textmate": "^5.2.0"
-			}
-		},
-		"node_modules/shiki-languages": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.5.tgz",
-			"integrity": "sha512-M3q1BFE2Qk/w72K9GM8kZaZ2yVSP4wd1gep9sYWaLJWQN4GhTuqC1oJrmX0JBX1PHECJqi39ZGYD39rQ6qrVvw==",
-			"dependencies": {
-				"vscode-textmate": "^5.2.0"
+				"ansi-sequence-parser": "^1.1.0",
+				"jsonc-parser": "^3.2.0",
+				"vscode-oniguruma": "^1.7.0",
+				"vscode-textmate": "^8.0.0"
 			}
 		},
 		"node_modules/shiki-themes": {
@@ -2455,6 +2427,11 @@
 				"json5": "^2.1.0",
 				"vscode-textmate": "^5.2.0"
 			}
+		},
+		"node_modules/shiki/node_modules/vscode-textmate": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.3",
@@ -2917,6 +2894,11 @@
 			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
+		"node_modules/vscode-oniguruma": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+		},
 		"node_modules/vscode-textmate": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
@@ -3163,11 +3145,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		}
 	},
 	"dependencies": {
@@ -3592,6 +3569,11 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true
+		},
+		"ansi-sequence-parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+			"integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -4521,6 +4503,11 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4585,14 +4572,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"requires": {
-				"yallist": "^3.0.2"
-			}
 		},
 		"marked": {
 			"version": "4.0.15",
@@ -4661,11 +4640,6 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4709,22 +4683,6 @@
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
-			}
-		},
-		"onigasm": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-			"integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-			"requires": {
-				"lru-cache": "^5.1.1"
-			}
-		},
-		"oniguruma": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.2.1.tgz",
-			"integrity": "sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==",
-			"requires": {
-				"nan": "^2.14.0"
 			}
 		},
 		"optionator": {
@@ -5019,22 +4977,21 @@
 			"dev": true
 		},
 		"shiki": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.5.tgz",
-			"integrity": "sha512-TwiRLuon4m+TMZ8Qdx8VgtIj4edzxmFjW+I7IjI7xyf2b7WjTXrynuk4iDMCjdsb8zVd9oFCxqhfyNC8LGeDNQ==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+			"integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
 			"requires": {
-				"onigasm": "^2.2.1",
-				"shiki-languages": "^0.2.5",
-				"shiki-themes": "^0.2.5",
-				"vscode-textmate": "^5.2.0"
-			}
-		},
-		"shiki-languages": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.5.tgz",
-			"integrity": "sha512-M3q1BFE2Qk/w72K9GM8kZaZ2yVSP4wd1gep9sYWaLJWQN4GhTuqC1oJrmX0JBX1PHECJqi39ZGYD39rQ6qrVvw==",
-			"requires": {
-				"vscode-textmate": "^5.2.0"
+				"ansi-sequence-parser": "^1.1.0",
+				"jsonc-parser": "^3.2.0",
+				"vscode-oniguruma": "^1.7.0",
+				"vscode-textmate": "^8.0.0"
+			},
+			"dependencies": {
+				"vscode-textmate": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+					"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
+				}
 			}
 		},
 		"shiki-themes": {
@@ -5391,6 +5348,11 @@
 			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
+		"vscode-oniguruma": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+		},
 		"vscode-textmate": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
@@ -5565,11 +5527,6 @@
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
-		},
-		"yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "docs-view",
 	"displayName": "Docs View",
 	"description": "Display documentation in the sidebar or panel.",
-	"version": "0.0.12",
+	"version": "0.0.11",
 	"publisher": "bierner",
 	"keywords": [
 		"documentation",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "docs-view",
 	"displayName": "Docs View",
 	"description": "Display documentation in the sidebar or panel.",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"publisher": "bierner",
 	"keywords": [
 		"documentation",
@@ -114,9 +114,9 @@
 	"dependencies": {
 		"json5": "^2.1.3",
 		"marked": "^4.0.15",
-		"oniguruma": "^7.2.1",
-		"shiki": "^0.2.5",
-		"shiki-themes": "^0.2.5"
+		"shiki": "^0.14.1",
+		"shiki-themes": "^0.2.5",
+		"vscode-oniguruma": "^1.7.0"
 	},
 	"devDependencies": {
 		"@types/json5": "0.0.30",

--- a/src/codeHighlighter.ts
+++ b/src/codeHighlighter.ts
@@ -107,11 +107,13 @@ export class CodeHighlighter {
 		}
 
 		if (typeof theme === 'string') {
-			theme = await shiki.loadTheme(theme as any)
+			// @ts-ignore
+			theme = shiki.getTheme(theme) as IShikiTheme
 		}
 
-		if (theme) {
+		if (theme && theme.colors) {
 			theme.bg = ' '; // Don't set bg so that we use the view's background instead
+			theme.colors['editor.background'] = ' ';
 		}
 		return theme;
 	}

--- a/src/codeHighlighter.ts
+++ b/src/codeHighlighter.ts
@@ -62,13 +62,10 @@ export class CodeHighlighter {
 		const highlighter = await this._highlighter;
 
 		return (code: string, inputLanguage: string): string => {
-			const language = inputLanguage || document.languageId;
-			if (language && highlighter) {
+			const languageId = inputLanguage || document.languageId;
+			if (languageId && highlighter) {
 				try {
-					const languageId = getLanguageId(language);
-					if (languageId) {
-						return highlighter.codeToHtml(code, { lang: languageId });
-					}
+					return highlighter.codeToHtml(code, { lang: languageId });
 				} catch (err) {
 					// noop
 				}
@@ -119,15 +116,6 @@ export class CodeHighlighter {
 	}
 }
 
-function getLanguageId(inId: string): string | undefined {
-	for (const language of languages) {
-		if (inId === language.name || language.identifiers.some(langId => inId === langId)) {
-			return language.language;
-		}
-	}
-	return undefined;
-}
-
 const defaultDarkForeground = '#cccccc';
 const defaultLightForeground = '#333333';
 
@@ -159,65 +147,3 @@ async function getDefaultForeground(uri: vscode.Uri): Promise<string> {
 		? defaultLightForeground
 		: defaultDarkForeground;
 }
-
-// Taken from https://github.com/Microsoft/vscode-markdown-tm-grammar/blob/master/build.js
-const languages = [
-	{ name: 'css', language: 'css', identifiers: ['css', 'css.erb'], source: 'source.css' },
-	{ name: 'basic', language: 'html', identifiers: ['html', 'htm', 'shtml', 'xhtml', 'inc', 'tmpl', 'tpl'], source: 'text.html.basic' },
-	{ name: 'ini', language: 'ini', identifiers: ['ini', 'conf'], source: 'source.ini' },
-	{ name: 'java', language: 'java', identifiers: ['java', 'bsh'], source: 'source.java' },
-	{ name: 'lua', language: 'lua', identifiers: ['lua'], source: 'source.lua' },
-	{ name: 'makefile', language: 'makefile', identifiers: ['Makefile', 'makefile', 'GNUmakefile', 'OCamlMakefile'], source: 'source.makefile' },
-	{ name: 'perl', language: 'perl', identifiers: ['perl', 'pl', 'pm', 'pod', 't', 'PL', 'psgi', 'vcl'], source: 'source.perl' },
-	{ name: 'r', language: 'r', identifiers: ['R', 'r', 's', 'S', 'Rprofile'], source: 'source.r' },
-	{ name: 'ruby', language: 'ruby', identifiers: ['ruby', 'rb', 'rbx', 'rjs', 'Rakefile', 'rake', 'cgi', 'fcgi', 'gemspec', 'irbrc', 'Capfile', 'ru', 'prawn', 'Cheffile', 'Gemfile', 'Guardfile', 'Hobofile', 'Vagrantfile', 'Appraisals', 'Rantfile', 'Berksfile', 'Berksfile.lock', 'Thorfile', 'Puppetfile'], source: 'source.ruby' },
-	// 	Left to its own devices, the PHP grammar will match HTML as a combination of operators
-	// and constants. Therefore, HTML must take precedence over PHP in order to get proper
-	// syntax highlighting.
-	{ name: 'php', language: 'php', identifiers: ['php', 'php3', 'php4', 'php5', 'phpt', 'phtml', 'aw', 'ctp'], source: ['text.html.basic', 'text.html.php', 'source.php'] },
-	{ name: 'sql', language: 'sql', identifiers: ['sql', 'ddl', 'dml'], source: 'source.sql' },
-	{ name: 'vs_net', language: 'vs_net', identifiers: ['vb'], source: 'source.asp.vb.net' },
-	{ name: 'xml', language: 'xml', identifiers: ['xml', 'xsd', 'tld', 'jsp', 'pt', 'cpt', 'dtml', 'rss', 'opml'], source: 'text.xml' },
-	{ name: 'xsl', language: 'xsl', identifiers: ['xsl', 'xslt'], source: 'text.xml.xsl' },
-	{ name: 'yaml', language: 'yaml', identifiers: ['yaml', 'yml'], source: 'source.yaml' },
-	{ name: 'dosbatch', language: 'dosbatch', identifiers: ['bat', 'batch'], source: 'source.batchfile' },
-	{ name: 'clojure', language: 'clojure', identifiers: ['clj', 'cljs', 'clojure'], source: 'source.clojure' },
-	{ name: 'coffee', language: 'coffee', identifiers: ['coffee', 'Cakefile', 'coffee.erb'], source: 'source.coffee' },
-	{ name: 'c', language: 'c', identifiers: ['c', 'h'], source: 'source.c' },
-	{ name: 'cpp', language: 'cpp', identifiers: ['cpp', 'c\\+\\+', 'cxx'], source: 'source.cpp' },
-	{ name: 'diff', language: 'diff', identifiers: ['patch', 'diff', 'rej'], source: 'source.diff' },
-	{ name: 'dockerfile', language: 'dockerfile', identifiers: ['dockerfile', 'Dockerfile'], source: 'source.dockerfile' },
-	{ name: 'git_commit', identifiers: ['COMMIT_EDITMSG', 'MERGE_MSG'], source: 'text.git-commit' },
-	{ name: 'git_rebase', identifiers: ['git-rebase-todo'], source: 'text.git-rebase' },
-	{ name: 'go', language: 'go', identifiers: ['go', 'golang'], source: 'source.go' },
-	{ name: 'groovy', language: 'groovy', identifiers: ['groovy', 'gvy'], source: 'source.groovy' },
-	{ name: 'pug', language: 'pug', identifiers: ['jade', 'pug'], source: 'text.pug' },
-
-	{ name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs'], source: 'source.js' },
-	{ name: 'js_regexp', identifiers: ['regexp'], source: 'source.js.regexp' },
-	{ name: 'json', language: 'json', identifiers: ['json', 'json5', 'sublime-settings', 'sublime-menu', 'sublime-keymap', 'sublime-mousemap', 'sublime-theme', 'sublime-build', 'sublime-project', 'sublime-completions'], source: 'source.json' },
-	{ name: 'jsonc', language: 'jsonc', identifiers: ['jsonc'], source: 'source.json.comments' },
-	{ name: 'less', language: 'less', identifiers: ['less'], source: 'source.css.less' },
-	{ name: 'objc', language: 'objc', identifiers: ['objectivec', 'objective-c', 'mm', 'objc', 'obj-c', 'm', 'h'], source: 'source.objc' },
-	{ name: 'swift', language: 'swift', identifiers: ['swift'], source: 'source.swift' },
-	{ name: 'scss', language: 'scss', identifiers: ['scss'], source: 'source.css.scss' },
-
-	{ name: 'perl6', language: 'perl6', identifiers: ['perl6', 'p6', 'pl6', 'pm6', 'nqp'], source: 'source.perl.6' },
-	{ name: 'powershell', language: 'powershell', identifiers: ['powershell', 'ps1', 'psm1', 'psd1'], source: 'source.powershell' },
-	{ name: 'python', language: 'python', identifiers: ['python', 'py', 'py3', 'rpy', 'pyw', 'cpy', 'SConstruct', 'Sconstruct', 'sconstruct', 'SConscript', 'gyp', 'gypi'], source: 'source.python' },
-	{ name: 'regexp_python', identifiers: ['re'], source: 'source.regexp.python' },
-	{ name: 'rust', language: 'rust', identifiers: ['rust', 'rs'], source: 'source.rust' },
-	{ name: 'scala', language: 'scala', identifiers: ['scala', 'sbt'], source: 'source.scala' },
-	{ name: 'shell', language: 'shellscript', identifiers: ['shell', 'sh', 'bash', 'zsh', 'bashrc', 'bash_profile', 'bash_login', 'profile', 'bash_logout', '.textmate_init'], source: 'source.shell' },
-	{ name: 'ts', language: 'typescript', identifiers: ['typescript', 'ts'], source: 'source.ts' },
-	{ name: 'tsx', language: 'typescriptreact', identifiers: ['tsx'], source: 'source.tsx' },
-	{ name: 'csharp', language: 'csharp', identifiers: ['cs', 'csharp', 'c#'], source: 'source.cs' },
-	{ name: 'fsharp', language: 'fsharp', identifiers: ['fs', 'fsharp', 'f#'], source: 'source.fsharp' },
-	{ name: 'dart', language: 'dart', identifiers: ['dart'], source: 'source.dart' },
-	{ name: 'handlebars', language: 'handlebars', identifiers: ['handlebars', 'hbs'], source: 'text.html.handlebars' },
-	{ name: 'markdown', language: 'markdown', identifiers: ['markdown', 'md'], source: 'text.html.markdown' },
-	{ name: 'haskell', language: 'haskell', identifiers: ['hs', 'lhs'], source: 'text.html.hs' },
-	{ name: 'ocaml', language: 'ocaml', identifiers: ['ml', 'mli', 'eliom', 'eliomi'], source: 'source.ocaml.interface' },
-	{ name: 'zig', language: 'zig', identifiers: ['zig'], source: 'source.zig' },
-	{ name: 'd', language: 'd', identifiers: ['d'], source: 'source.d' },
-];

--- a/src/codeHighlighter.ts
+++ b/src/codeHighlighter.ts
@@ -1,7 +1,7 @@
 import json5 from 'json5';
 import * as shiki from 'shiki';
-import type { IShikiTheme, Theme } from 'shiki-themes';
-import { Highlighter } from 'shiki/dist/highlighter';
+import { Highlighter } from 'shiki'
+import type { Theme, IShikiTheme } from 'shiki'
 import * as vscode from 'vscode';
 
 declare const TextDecoder: any;
@@ -67,7 +67,7 @@ export class CodeHighlighter {
 				try {
 					const languageId = getLanguageId(language);
 					if (languageId) {
-						return highlighter.codeToHtml!(code, languageId);
+						return highlighter.codeToHtml(code, { lang: languageId });
 					}
 				} catch (err) {
 					// noop
@@ -86,13 +86,14 @@ export class CodeHighlighter {
 	private static async getShikiTheme(): Promise<IShikiTheme | undefined> {
 		let theme: string | IShikiTheme | undefined;
 
-		const currentThemeName = vscode.workspace.getConfiguration('workbench').get<string>('colorTheme');
+		const currentThemeName = vscode.workspace.getConfiguration('workbench').get<string>('colorTheme') || "random";
+
 		if (currentThemeName && defaultThemesMap.has(currentThemeName)) {
 			theme = defaultThemesMap.get(currentThemeName);
 		} else if (currentThemeName) {
 			const colorThemePath = getCurrentThemePath(currentThemeName);
 			if (colorThemePath) {
-				theme = shiki.loadTheme(colorThemePath.fsPath);
+				theme = await shiki.loadTheme(colorThemePath.fsPath);
 
 				theme.name = 'random'; // Shiki doesn't work without name and defaults to `Nord`
 
@@ -107,11 +108,12 @@ export class CodeHighlighter {
 		}
 
 		if (typeof theme === 'string') {
-			theme = shiki.getTheme(theme as any);
+			// theme = await shiki.getTheme(theme as any);
+			theme = await shiki.loadTheme(currentThemeName)
 		}
 
 		if (theme) {
-			theme.bg = ' '; // Don't set bg so that we use the view's background instead
+			// theme.bg = ' '; // Don't set bg so that we use the view's background instead
 		}
 		return theme;
 	}
@@ -167,12 +169,12 @@ const languages = [
 	{ name: 'lua', language: 'lua', identifiers: ['lua'], source: 'source.lua' },
 	{ name: 'makefile', language: 'makefile', identifiers: ['Makefile', 'makefile', 'GNUmakefile', 'OCamlMakefile'], source: 'source.makefile' },
 	{ name: 'perl', language: 'perl', identifiers: ['perl', 'pl', 'pm', 'pod', 't', 'PL', 'psgi', 'vcl'], source: 'source.perl' },
-	{ name: 'r', language: 'r', identifiers: ['R', 'r', 's', 'S', 'Rprofile'], source: 'source.r' },
+	{ name: 'r', language: 'r', identifiers: ['R', 'r', 's', 'S', 'Rprofile', '\\{\\.r.+?\\}'], source: 'source.r' },
 	{ name: 'ruby', language: 'ruby', identifiers: ['ruby', 'rb', 'rbx', 'rjs', 'Rakefile', 'rake', 'cgi', 'fcgi', 'gemspec', 'irbrc', 'Capfile', 'ru', 'prawn', 'Cheffile', 'Gemfile', 'Guardfile', 'Hobofile', 'Vagrantfile', 'Appraisals', 'Rantfile', 'Berksfile', 'Berksfile.lock', 'Thorfile', 'Puppetfile'], source: 'source.ruby' },
 	// 	Left to its own devices, the PHP grammar will match HTML as a combination of operators
 	// and constants. Therefore, HTML must take precedence over PHP in order to get proper
 	// syntax highlighting.
-	{ name: 'php', language: 'php', identifiers: ['php', 'php3', 'php4', 'php5', 'phpt', 'phtml', 'aw', 'ctp'], source: ['text.html.basic', 'text.html.php', 'source.php'] },
+	{ name: 'php', language: 'php', identifiers: ['php', 'php3', 'php4', 'php5', 'phpt', 'phtml', 'aw', 'ctp'], source: ['text.html.basic', 'source.php'] },
 	{ name: 'sql', language: 'sql', identifiers: ['sql', 'ddl', 'dml'], source: 'source.sql' },
 	{ name: 'vs_net', language: 'vs_net', identifiers: ['vb'], source: 'source.asp.vb.net' },
 	{ name: 'xml', language: 'xml', identifiers: ['xml', 'xsd', 'tld', 'jsp', 'pt', 'cpt', 'dtml', 'rss', 'opml'], source: 'text.xml' },
@@ -182,7 +184,7 @@ const languages = [
 	{ name: 'clojure', language: 'clojure', identifiers: ['clj', 'cljs', 'clojure'], source: 'source.clojure' },
 	{ name: 'coffee', language: 'coffee', identifiers: ['coffee', 'Cakefile', 'coffee.erb'], source: 'source.coffee' },
 	{ name: 'c', language: 'c', identifiers: ['c', 'h'], source: 'source.c' },
-	{ name: 'cpp', language: 'cpp', identifiers: ['cpp', 'c\\+\\+', 'cxx'], source: 'source.cpp' },
+	{ name: 'cpp', language: 'cpp', identifiers: ['cpp', 'c\\+\\+', 'cxx'], source: 'source.cpp', additionalContentName: ['source.cpp'] },
 	{ name: 'diff', language: 'diff', identifiers: ['patch', 'diff', 'rej'], source: 'source.diff' },
 	{ name: 'dockerfile', language: 'dockerfile', identifiers: ['dockerfile', 'Dockerfile'], source: 'source.dockerfile' },
 	{ name: 'git_commit', identifiers: ['COMMIT_EDITMSG', 'MERGE_MSG'], source: 'text.git-commit' },
@@ -191,7 +193,7 @@ const languages = [
 	{ name: 'groovy', language: 'groovy', identifiers: ['groovy', 'gvy'], source: 'source.groovy' },
 	{ name: 'pug', language: 'pug', identifiers: ['jade', 'pug'], source: 'text.pug' },
 
-	{ name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs'], source: 'source.js' },
+	{ name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs', 'cjs', 'dataviewjs', '\\{\\.js.+?\\}'], source: 'source.js' },
 	{ name: 'js_regexp', identifiers: ['regexp'], source: 'source.js.regexp' },
 	{ name: 'json', language: 'json', identifiers: ['json', 'json5', 'sublime-settings', 'sublime-menu', 'sublime-keymap', 'sublime-mousemap', 'sublime-theme', 'sublime-build', 'sublime-project', 'sublime-completions'], source: 'source.json' },
 	{ name: 'jsonc', language: 'jsonc', identifiers: ['jsonc'], source: 'source.json.comments' },
@@ -202,11 +204,12 @@ const languages = [
 
 	{ name: 'perl6', language: 'perl6', identifiers: ['perl6', 'p6', 'pl6', 'pm6', 'nqp'], source: 'source.perl.6' },
 	{ name: 'powershell', language: 'powershell', identifiers: ['powershell', 'ps1', 'psm1', 'psd1'], source: 'source.powershell' },
-	{ name: 'python', language: 'python', identifiers: ['python', 'py', 'py3', 'rpy', 'pyw', 'cpy', 'SConstruct', 'Sconstruct', 'sconstruct', 'SConscript', 'gyp', 'gypi'], source: 'source.python' },
+	{ name: 'python', language: 'python', identifiers: ['python', 'py', 'py3', 'rpy', 'pyw', 'cpy', 'SConstruct', 'Sconstruct', 'sconstruct', 'SConscript', 'gyp', 'gypi', '\\{\\.python.+?\\}'], source: 'source.python' },
+	{ name: 'julia', language: 'julia', identifiers: ['julia', '\\{\\.julia.+?\\}'], source: 'source.julia' },
 	{ name: 'regexp_python', identifiers: ['re'], source: 'source.regexp.python' },
-	{ name: 'rust', language: 'rust', identifiers: ['rust', 'rs'], source: 'source.rust' },
+	{ name: 'rust', language: 'rust', identifiers: ['rust', 'rs', '\\{\\.rust.+?\\}'], source: 'source.rust' },
 	{ name: 'scala', language: 'scala', identifiers: ['scala', 'sbt'], source: 'source.scala' },
-	{ name: 'shell', language: 'shellscript', identifiers: ['shell', 'sh', 'bash', 'zsh', 'bashrc', 'bash_profile', 'bash_login', 'profile', 'bash_logout', '.textmate_init'], source: 'source.shell' },
+	{ name: 'shell', language: 'shellscript', identifiers: ['shell', 'sh', 'bash', 'zsh', 'bashrc', 'bash_profile', 'bash_login', 'profile', 'bash_logout', '.textmate_init', '\\{\\.bash.+?\\}'], source: 'source.shell' },
 	{ name: 'ts', language: 'typescript', identifiers: ['typescript', 'ts'], source: 'source.ts' },
 	{ name: 'tsx', language: 'typescriptreact', identifiers: ['tsx'], source: 'source.tsx' },
 	{ name: 'csharp', language: 'csharp', identifiers: ['cs', 'csharp', 'c#'], source: 'source.cs' },
@@ -214,8 +217,10 @@ const languages = [
 	{ name: 'dart', language: 'dart', identifiers: ['dart'], source: 'source.dart' },
 	{ name: 'handlebars', language: 'handlebars', identifiers: ['handlebars', 'hbs'], source: 'text.html.handlebars' },
 	{ name: 'markdown', language: 'markdown', identifiers: ['markdown', 'md'], source: 'text.html.markdown' },
-	{ name: 'haskell', language: 'haskell', identifiers: ['hs', 'lhs'], source: 'text.html.hs' },
-	{ name: 'ocaml', language: 'ocaml', identifiers: ['ml', 'mli', 'eliom', 'eliomi'], source: 'source.ocaml.interface' },	
-	{ name: 'zig', language: 'zig', identifiers: ['zig'], source: 'source.zig' },
-	{ name: 'd', language: 'd', identifiers: ['d'], source: 'source.d' },
+	{ name: 'log', language: 'log', identifiers: ['log'], source: 'text.log' },
+	{ name: 'erlang', language: 'erlang', identifiers: ['erlang'], source: 'source.erlang' },
+	{ name: 'elixir', language: 'elixir', identifiers: ['elixir'], source: 'source.elixir' },
+	{ name: 'latex', language: 'latex', identifiers: ['latex', 'tex'], source: 'text.tex.latex' },
+	{ name: 'bibtex', language: 'bibtex', identifiers: ['bibtex'], source: 'text.bibtex' },
+	{ name: 'twig', language: 'twig', identifiers: ['twig'], source: 'source.twig' },
 ];

--- a/src/codeHighlighter.ts
+++ b/src/codeHighlighter.ts
@@ -86,8 +86,7 @@ export class CodeHighlighter {
 	private static async getShikiTheme(): Promise<IShikiTheme | undefined> {
 		let theme: string | IShikiTheme | undefined;
 
-		const currentThemeName = vscode.workspace.getConfiguration('workbench').get<string>('colorTheme') || "random";
-
+		const currentThemeName = vscode.workspace.getConfiguration('workbench').get<string>('colorTheme');
 		if (currentThemeName && defaultThemesMap.has(currentThemeName)) {
 			theme = defaultThemesMap.get(currentThemeName);
 		} else if (currentThemeName) {
@@ -108,12 +107,11 @@ export class CodeHighlighter {
 		}
 
 		if (typeof theme === 'string') {
-			// theme = await shiki.getTheme(theme as any);
-			theme = await shiki.loadTheme(currentThemeName)
+			theme = await shiki.loadTheme(theme as any)
 		}
 
 		if (theme) {
-			// theme.bg = ' '; // Don't set bg so that we use the view's background instead
+			theme.bg = ' '; // Don't set bg so that we use the view's background instead
 		}
 		return theme;
 	}
@@ -169,12 +167,12 @@ const languages = [
 	{ name: 'lua', language: 'lua', identifiers: ['lua'], source: 'source.lua' },
 	{ name: 'makefile', language: 'makefile', identifiers: ['Makefile', 'makefile', 'GNUmakefile', 'OCamlMakefile'], source: 'source.makefile' },
 	{ name: 'perl', language: 'perl', identifiers: ['perl', 'pl', 'pm', 'pod', 't', 'PL', 'psgi', 'vcl'], source: 'source.perl' },
-	{ name: 'r', language: 'r', identifiers: ['R', 'r', 's', 'S', 'Rprofile', '\\{\\.r.+?\\}'], source: 'source.r' },
+	{ name: 'r', language: 'r', identifiers: ['R', 'r', 's', 'S', 'Rprofile'], source: 'source.r' },
 	{ name: 'ruby', language: 'ruby', identifiers: ['ruby', 'rb', 'rbx', 'rjs', 'Rakefile', 'rake', 'cgi', 'fcgi', 'gemspec', 'irbrc', 'Capfile', 'ru', 'prawn', 'Cheffile', 'Gemfile', 'Guardfile', 'Hobofile', 'Vagrantfile', 'Appraisals', 'Rantfile', 'Berksfile', 'Berksfile.lock', 'Thorfile', 'Puppetfile'], source: 'source.ruby' },
 	// 	Left to its own devices, the PHP grammar will match HTML as a combination of operators
 	// and constants. Therefore, HTML must take precedence over PHP in order to get proper
 	// syntax highlighting.
-	{ name: 'php', language: 'php', identifiers: ['php', 'php3', 'php4', 'php5', 'phpt', 'phtml', 'aw', 'ctp'], source: ['text.html.basic', 'source.php'] },
+	{ name: 'php', language: 'php', identifiers: ['php', 'php3', 'php4', 'php5', 'phpt', 'phtml', 'aw', 'ctp'], source: ['text.html.basic', 'text.html.php', 'source.php'] },
 	{ name: 'sql', language: 'sql', identifiers: ['sql', 'ddl', 'dml'], source: 'source.sql' },
 	{ name: 'vs_net', language: 'vs_net', identifiers: ['vb'], source: 'source.asp.vb.net' },
 	{ name: 'xml', language: 'xml', identifiers: ['xml', 'xsd', 'tld', 'jsp', 'pt', 'cpt', 'dtml', 'rss', 'opml'], source: 'text.xml' },
@@ -184,7 +182,7 @@ const languages = [
 	{ name: 'clojure', language: 'clojure', identifiers: ['clj', 'cljs', 'clojure'], source: 'source.clojure' },
 	{ name: 'coffee', language: 'coffee', identifiers: ['coffee', 'Cakefile', 'coffee.erb'], source: 'source.coffee' },
 	{ name: 'c', language: 'c', identifiers: ['c', 'h'], source: 'source.c' },
-	{ name: 'cpp', language: 'cpp', identifiers: ['cpp', 'c\\+\\+', 'cxx'], source: 'source.cpp', additionalContentName: ['source.cpp'] },
+	{ name: 'cpp', language: 'cpp', identifiers: ['cpp', 'c\\+\\+', 'cxx'], source: 'source.cpp' },
 	{ name: 'diff', language: 'diff', identifiers: ['patch', 'diff', 'rej'], source: 'source.diff' },
 	{ name: 'dockerfile', language: 'dockerfile', identifiers: ['dockerfile', 'Dockerfile'], source: 'source.dockerfile' },
 	{ name: 'git_commit', identifiers: ['COMMIT_EDITMSG', 'MERGE_MSG'], source: 'text.git-commit' },
@@ -193,7 +191,7 @@ const languages = [
 	{ name: 'groovy', language: 'groovy', identifiers: ['groovy', 'gvy'], source: 'source.groovy' },
 	{ name: 'pug', language: 'pug', identifiers: ['jade', 'pug'], source: 'text.pug' },
 
-	{ name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs', 'cjs', 'dataviewjs', '\\{\\.js.+?\\}'], source: 'source.js' },
+	{ name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs'], source: 'source.js' },
 	{ name: 'js_regexp', identifiers: ['regexp'], source: 'source.js.regexp' },
 	{ name: 'json', language: 'json', identifiers: ['json', 'json5', 'sublime-settings', 'sublime-menu', 'sublime-keymap', 'sublime-mousemap', 'sublime-theme', 'sublime-build', 'sublime-project', 'sublime-completions'], source: 'source.json' },
 	{ name: 'jsonc', language: 'jsonc', identifiers: ['jsonc'], source: 'source.json.comments' },
@@ -204,12 +202,11 @@ const languages = [
 
 	{ name: 'perl6', language: 'perl6', identifiers: ['perl6', 'p6', 'pl6', 'pm6', 'nqp'], source: 'source.perl.6' },
 	{ name: 'powershell', language: 'powershell', identifiers: ['powershell', 'ps1', 'psm1', 'psd1'], source: 'source.powershell' },
-	{ name: 'python', language: 'python', identifiers: ['python', 'py', 'py3', 'rpy', 'pyw', 'cpy', 'SConstruct', 'Sconstruct', 'sconstruct', 'SConscript', 'gyp', 'gypi', '\\{\\.python.+?\\}'], source: 'source.python' },
-	{ name: 'julia', language: 'julia', identifiers: ['julia', '\\{\\.julia.+?\\}'], source: 'source.julia' },
+	{ name: 'python', language: 'python', identifiers: ['python', 'py', 'py3', 'rpy', 'pyw', 'cpy', 'SConstruct', 'Sconstruct', 'sconstruct', 'SConscript', 'gyp', 'gypi'], source: 'source.python' },
 	{ name: 'regexp_python', identifiers: ['re'], source: 'source.regexp.python' },
-	{ name: 'rust', language: 'rust', identifiers: ['rust', 'rs', '\\{\\.rust.+?\\}'], source: 'source.rust' },
+	{ name: 'rust', language: 'rust', identifiers: ['rust', 'rs'], source: 'source.rust' },
 	{ name: 'scala', language: 'scala', identifiers: ['scala', 'sbt'], source: 'source.scala' },
-	{ name: 'shell', language: 'shellscript', identifiers: ['shell', 'sh', 'bash', 'zsh', 'bashrc', 'bash_profile', 'bash_login', 'profile', 'bash_logout', '.textmate_init', '\\{\\.bash.+?\\}'], source: 'source.shell' },
+	{ name: 'shell', language: 'shellscript', identifiers: ['shell', 'sh', 'bash', 'zsh', 'bashrc', 'bash_profile', 'bash_login', 'profile', 'bash_logout', '.textmate_init'], source: 'source.shell' },
 	{ name: 'ts', language: 'typescript', identifiers: ['typescript', 'ts'], source: 'source.ts' },
 	{ name: 'tsx', language: 'typescriptreact', identifiers: ['tsx'], source: 'source.tsx' },
 	{ name: 'csharp', language: 'csharp', identifiers: ['cs', 'csharp', 'c#'], source: 'source.cs' },
@@ -217,10 +214,8 @@ const languages = [
 	{ name: 'dart', language: 'dart', identifiers: ['dart'], source: 'source.dart' },
 	{ name: 'handlebars', language: 'handlebars', identifiers: ['handlebars', 'hbs'], source: 'text.html.handlebars' },
 	{ name: 'markdown', language: 'markdown', identifiers: ['markdown', 'md'], source: 'text.html.markdown' },
-	{ name: 'log', language: 'log', identifiers: ['log'], source: 'text.log' },
-	{ name: 'erlang', language: 'erlang', identifiers: ['erlang'], source: 'source.erlang' },
-	{ name: 'elixir', language: 'elixir', identifiers: ['elixir'], source: 'source.elixir' },
-	{ name: 'latex', language: 'latex', identifiers: ['latex', 'tex'], source: 'text.tex.latex' },
-	{ name: 'bibtex', language: 'bibtex', identifiers: ['bibtex'], source: 'text.bibtex' },
-	{ name: 'twig', language: 'twig', identifiers: ['twig'], source: 'source.twig' },
+	{ name: 'haskell', language: 'haskell', identifiers: ['hs', 'lhs'], source: 'text.html.hs' },
+	{ name: 'ocaml', language: 'ocaml', identifiers: ['ml', 'mli', 'eliom', 'eliomi'], source: 'source.ocaml.interface' },
+	{ name: 'zig', language: 'zig', identifiers: ['zig'], source: 'source.zig' },
+	{ name: 'd', language: 'd', identifiers: ['d'], source: 'source.d' },
 ];


### PR DESCRIPTION
vscode already provides language identification. this pr removes internal language lookup to rely on vscode instead. 