### PR TITLE
fix syntax highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
 				"json5": "^2.1.3",
 				"marked": "^4.0.15",
 				"oniguruma": "^7.2.1",
-				"shiki": "^0.2.5",
-				"shiki-themes": "^0.2.5"
+				"shiki": "^0.14.7"
 			},
 			"devDependencies": {
 				"@types/json5": "0.0.30",
@@ -568,6 +567,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/ansi-sequence-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
 		},
 		"node_modules/ansi-styles": {
 			"version": "3.2.1",
@@ -1786,6 +1790,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -1866,14 +1875,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"node_modules/lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"dependencies": {
-				"yallist": "^3.0.2"
-			}
 		},
 		"node_modules/marked": {
 			"version": "4.0.15",
@@ -2020,14 +2021,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/onigasm": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-			"integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-			"dependencies": {
-				"lru-cache": "^5.1.1"
 			}
 		},
 		"node_modules/oniguruma": {
@@ -2429,31 +2422,14 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.5.tgz",
-			"integrity": "sha512-TwiRLuon4m+TMZ8Qdx8VgtIj4edzxmFjW+I7IjI7xyf2b7WjTXrynuk4iDMCjdsb8zVd9oFCxqhfyNC8LGeDNQ==",
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
 			"dependencies": {
-				"onigasm": "^2.2.1",
-				"shiki-languages": "^0.2.5",
-				"shiki-themes": "^0.2.5",
-				"vscode-textmate": "^5.2.0"
-			}
-		},
-		"node_modules/shiki-languages": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.5.tgz",
-			"integrity": "sha512-M3q1BFE2Qk/w72K9GM8kZaZ2yVSP4wd1gep9sYWaLJWQN4GhTuqC1oJrmX0JBX1PHECJqi39ZGYD39rQ6qrVvw==",
-			"dependencies": {
-				"vscode-textmate": "^5.2.0"
-			}
-		},
-		"node_modules/shiki-themes": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.5.tgz",
-			"integrity": "sha512-jL2IpczDT1B6vpmLvwq8PbIVgdWUZ+8C7A7sBDAH2dsoFEMSk4OxeGByaNKxFRZgx40wFDyCCriC2JIQDPnHBQ==",
-			"dependencies": {
-				"json5": "^2.1.0",
-				"vscode-textmate": "^5.2.0"
+				"ansi-sequence-parser": "^1.1.0",
+				"jsonc-parser": "^3.2.0",
+				"vscode-oniguruma": "^1.7.0",
+				"vscode-textmate": "^8.0.0"
 			}
 		},
 		"node_modules/signal-exit": {
@@ -2917,10 +2893,15 @@
 			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
+		"node_modules/vscode-oniguruma": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+		},
 		"node_modules/vscode-textmate": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
 		},
 		"node_modules/watchpack": {
 			"version": "2.3.1",
@@ -3163,11 +3144,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		}
 	},
 	"dependencies": {
@@ -3592,6 +3568,11 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true
+		},
+		"ansi-sequence-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -4521,6 +4502,11 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4585,14 +4571,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"requires": {
-				"yallist": "^3.0.2"
-			}
 		},
 		"marked": {
 			"version": "4.0.15",
@@ -4709,14 +4687,6 @@
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
-			}
-		},
-		"onigasm": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-			"integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-			"requires": {
-				"lru-cache": "^5.1.1"
 			}
 		},
 		"oniguruma": {
@@ -5019,31 +4989,14 @@
 			"dev": true
 		},
 		"shiki": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.5.tgz",
-			"integrity": "sha512-TwiRLuon4m+TMZ8Qdx8VgtIj4edzxmFjW+I7IjI7xyf2b7WjTXrynuk4iDMCjdsb8zVd9oFCxqhfyNC8LGeDNQ==",
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
 			"requires": {
-				"onigasm": "^2.2.1",
-				"shiki-languages": "^0.2.5",
-				"shiki-themes": "^0.2.5",
-				"vscode-textmate": "^5.2.0"
-			}
-		},
-		"shiki-languages": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.5.tgz",
-			"integrity": "sha512-M3q1BFE2Qk/w72K9GM8kZaZ2yVSP4wd1gep9sYWaLJWQN4GhTuqC1oJrmX0JBX1PHECJqi39ZGYD39rQ6qrVvw==",
-			"requires": {
-				"vscode-textmate": "^5.2.0"
-			}
-		},
-		"shiki-themes": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.5.tgz",
-			"integrity": "sha512-jL2IpczDT1B6vpmLvwq8PbIVgdWUZ+8C7A7sBDAH2dsoFEMSk4OxeGByaNKxFRZgx40wFDyCCriC2JIQDPnHBQ==",
-			"requires": {
-				"json5": "^2.1.0",
-				"vscode-textmate": "^5.2.0"
+				"ansi-sequence-parser": "^1.1.0",
+				"jsonc-parser": "^3.2.0",
+				"vscode-oniguruma": "^1.7.0",
+				"vscode-textmate": "^8.0.0"
 			}
 		},
 		"signal-exit": {
@@ -5391,10 +5344,15 @@
 			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
+		"vscode-oniguruma": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+		},
 		"vscode-textmate": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
 		},
 		"watchpack": {
 			"version": "2.3.1",
@@ -5565,11 +5523,6 @@
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
-		},
-		"yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -115,8 +115,7 @@
 		"json5": "^2.1.3",
 		"marked": "^4.0.15",
 		"oniguruma": "^7.2.1",
-		"shiki": "^0.2.5",
-		"shiki-themes": "^0.2.5"
+		"shiki": "^0.14.7"
 	},
 	"devDependencies": {
 		"@types/json5": "0.0.30",

--- a/src/codeHighlighter.ts
+++ b/src/codeHighlighter.ts
@@ -1,7 +1,7 @@
 import json5 from 'json5';
 import * as shiki from 'shiki';
-import type { IShikiTheme, Theme } from 'shiki-themes';
-import { Highlighter } from 'shiki/dist/highlighter';
+import type { IShikiTheme, Theme } from 'shiki';
+import { Highlighter } from 'shiki';
 import * as vscode from 'vscode';
 
 declare const TextDecoder: any;
@@ -92,7 +92,7 @@ export class CodeHighlighter {
 		} else if (currentThemeName) {
 			const colorThemePath = getCurrentThemePath(currentThemeName);
 			if (colorThemePath) {
-				theme = shiki.loadTheme(colorThemePath.fsPath);
+				theme = await shiki.loadTheme(colorThemePath.fsPath);
 
 				theme.name = 'random'; // Shiki doesn't work without name and defaults to `Nord`
 
@@ -107,7 +107,7 @@ export class CodeHighlighter {
 		}
 
 		if (typeof theme === 'string') {
-			theme = shiki.getTheme(theme as any);
+			theme = await shiki.loadTheme(theme as any);
 		}
 
 		if (theme) {


### PR DESCRIPTION
This is the bare minimum change needed to fix syntax highlighting. I assume that something changed in a recent version of VSCode that caused `shiki-themes` to break with the error:

```
TypeError: Cannot read properties of undefined (reading 'concat')
	at Object.loadTheme (/home/bryan/code/github.com/vscode-docs-view/node_modules/shiki-themes/dist/loadTheme.js:53:55)
	at CodeHighlighter.getShikiTheme (/home/bryan/code/github.com/vscode-docs-view/dist/extension.js:93:60)
```

With this fix, syntax highlighting works again:

![image](https://github.com/mattbierner/vscode-docs-view/assets/978899/c24561c0-e511-46ab-b4c8-35089f9d81b0)

---

@mattbierner There are many other improvements that can be made to this extension, but I tried to keep this PR to a minimum. Are you interested in help maintaining this project? I find it useful; imo a feature that VSCode should have natively.