### PR TITLE
Add Markdown support by markdown-it-texmath

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
-			// "preLaunchTask": "npm: webpack"
+			"preLaunchTask": "npm: webpack"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "webpack",
+			"problemMatcher": [],
+			"label": "npm: webpack",
+			"detail": " node -v"
+		}
+	]
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,13 +1,12 @@
 .vscode
-design
-node_modules
+design/**
 package-json.lock
 tsconfig.json
+webpack.config.js
+.gitignore
+.git
 webpack.config.js
 
 **/*.ts
 **/*.map
 
-# Explicitly include non-bundled node_modules
-!node_modules
-node_modules/marked

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ VS Code extension that displays hover documentation in the sidebar or panel.
 - Language independent. Works in any language that supports hovers.
 - The "Documentation" view shows in the panel by default. Move to other views or the panel just by dragging.
 - Supports syntax highlighting and markdown rendering in the docs view.
+- As opposed to the hover view it supports math rendering.
 
 ## Configuration
 
@@ -24,3 +25,7 @@ VS Code extension that displays hover documentation in the sidebar or panel.
 
 - `Pin current docs` — Stop live updating of the docs view. Keeps the currently visible docs. 
 - `Unpin current docs` — Make the docs view start tracking the cursor again.
+
+## Math rendering
+
+For math rendering the extension relies on the language server to return math blocks in a symbol's documentation. E.g. Pylance returns code blocks instead of math when reST is used for the docstring, therefore math rendering will not work. One can prevent this by either using the Jedi language server (by the `python.languageServer` setting) or by using markdown delimiters (`$` or `$$`) for math equations.

--- a/media/main.css
+++ b/media/main.css
@@ -2,9 +2,6 @@ body {
 	word-wrap: break-word;
 	margin: 1em 0;
 	padding: 0;
-
-	font-size: 12px;
-	line-height: 17px;
 }
 pre.shiki {
 	background: none !important;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
 				"dompurify": "^3.0.8",
 				"jsdom": "^23.2.0",
 				"json5": "^2.1.3",
-				"marked": "^11.1.0",
+				"katex": "^0.16.11",
+				"markdown-it": "^14.1.0",
+				"markdown-it-texmath": "^1.0.0",
 				"oniguruma": "^7.2.1",
 				"shiki": "^0.14.7"
 			},
@@ -854,8 +856,7 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -2171,6 +2172,29 @@
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
 		},
+		"node_modules/katex": {
+			"version": "0.16.11",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
+			"integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2200,6 +2224,14 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
 			}
 		},
 		"node_modules/loader-runner": {
@@ -2255,21 +2287,36 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/marked": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-11.1.1.tgz",
-			"integrity": "sha512-EgxRjgK9axsQuUa/oKMx5DEY8oXpKJfk61rT5iY3aRlgU6QJtUcxU5OAymdhCvWvhYcd9FKmO5eQoX8m9VGJXg==",
-			"bin": {
-				"marked": "bin/marked.js"
+		"node_modules/markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
 			},
-			"engines": {
-				"node": ">= 18"
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
 			}
+		},
+		"node_modules/markdown-it-texmath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-texmath/-/markdown-it-texmath-1.0.0.tgz",
+			"integrity": "sha512-4hhkiX8/gus+6e53PLCUmUrsa6ZWGgJW2XCW6O0ASvZUiezIK900ZicinTDtG3kAO2kon7oUA/ReWmpW2FByxg=="
 		},
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
 			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
 		},
 		"node_modules/memory-fs": {
 			"version": "0.5.0",
@@ -2570,6 +2617,14 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -3126,6 +3181,11 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
 		},
 		"node_modules/universalify": {
 			"version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
 				"@types/dompurify": "^3.0.5",
 				"@types/jsdom": "^21.1.6",
 				"@types/json5": "0.0.30",
+				"@types/katex": "^0.16.7",
+				"@types/markdown-it": "^14.1.2",
 				"@types/node": "^14.11.2",
 				"@types/vscode": "^1.75.0",
 				"@typescript-eslint/eslint-plugin": "^6.19.0",
@@ -346,6 +348,38 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
 			"integrity": "sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==",
 			"dev": true
+		},
+		"node_modules/@types/katex": {
+			"version": "0.16.7",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+			"integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/markdown-it": {
+			"version": "14.1.2",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/linkify-it": "^5",
+				"@types/mdurl": "^2"
+			}
+		},
+		"node_modules/@types/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "14.18.63",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
 				"json5": "^2.1.3",
 				"katex": "^0.16.11",
 				"markdown-it": "^14.1.0",
+				"markdown-it-table-of-contents": "^0.8.0",
 				"markdown-it-texmath": "^1.0.0",
+				"marked": "^14.1.2",
 				"oniguruma": "^7.2.1",
 				"shiki": "^0.14.7"
 			},
@@ -2337,10 +2339,31 @@
 				"markdown-it": "bin/markdown-it.mjs"
 			}
 		},
+		"node_modules/markdown-it-table-of-contents": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.8.0.tgz",
+			"integrity": "sha512-ihgUROZLw4ZsojxXrNZJP+VxYL4yTino51TP7eVYccEwgsYGC6CNXxv5G5JI89NhUb52wiRaMhEtWpiMAeRirA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">6.4.0"
+			}
+		},
 		"node_modules/markdown-it-texmath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/markdown-it-texmath/-/markdown-it-texmath-1.0.0.tgz",
 			"integrity": "sha512-4hhkiX8/gus+6e53PLCUmUrsa6ZWGgJW2XCW6O0ASvZUiezIK900ZicinTDtG3kAO2kon7oUA/ReWmpW2FByxg=="
+		},
+		"node_modules/marked": {
+			"version": "14.1.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-14.1.2.tgz",
+			"integrity": "sha512-f3r0yqpz31VXiDB/wj9GaOB0a2PRLQl6vJmXiFrniNwjkKdvakqJRULhjFKJpxOchlCRiG5fcacoUZY5Xa6PEQ==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
 		},
 		"node_modules/mdn-data": {
 			"version": "2.0.30",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,9 @@
 		"dompurify": "^3.0.8",
 		"jsdom": "^23.2.0",
 		"json5": "^2.1.3",
-		"marked": "^11.1.0",
+		"katex": "^0.16.11",
+		"markdown-it": "^14.1.0",
+		"markdown-it-texmath": "^1.0.0",
 		"oniguruma": "^7.2.1",
 		"shiki": "^0.14.7"
 	},

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
 		"@types/dompurify": "^3.0.5",
 		"@types/jsdom": "^21.1.6",
 		"@types/json5": "0.0.30",
+		"@types/katex": "^0.16.7",
+		"@types/markdown-it": "^14.1.2",
 		"@types/node": "^14.11.2",
 		"@types/vscode": "^1.75.0",
 		"@typescript-eslint/eslint-plugin": "^6.19.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
 						"The documentation view tracks the current cursor position. Display empty content if no documentation is found at the current position.",
 						"The documentation view tries to show the documentation at the current cursor position. If there is none, it continues showing the last available documentation."
 					]
+				},
+				"docsView.documentationView.fontSize": {
+					"type": "number",
+					"default": 12,
+					"description": "Controls the font size in the documentation view."
 				}
 			}
 		}
@@ -112,7 +117,9 @@
 		"json5": "^2.1.3",
 		"katex": "^0.16.11",
 		"markdown-it": "^14.1.0",
+		"markdown-it-table-of-contents": "^0.8.0",
 		"markdown-it-texmath": "^1.0.0",
+		"marked": "^14.1.2",
 		"oniguruma": "^7.2.1",
 		"shiki": "^0.14.7"
 	},

--- a/src/docsView.ts
+++ b/src/docsView.ts
@@ -112,6 +112,7 @@ export class DocsViewViewProvider implements vscode.WebviewViewProvider {
 	private _getHtmlForWebview(webview: vscode.Webview) {
 		const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'main.js'));
 		const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'main.css'));
+		const externalStyleUri = "https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
 
 		const nonce = getNonce();
 
@@ -122,13 +123,14 @@ export class DocsViewViewProvider implements vscode.WebviewViewProvider {
 
 				<meta http-equiv="Content-Security-Policy" content="
 					default-src 'none';
-					style-src ${webview.cspSource} 'unsafe-inline';
+					style-src ${webview.cspSource} 'unsafe-inline' https://cdn.jsdelivr.net;
 					script-src 'nonce-${nonce}';
 					img-src data: https:;
 					">
 
 				<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+				<link rel="stylesheet" href="${externalStyleUri}">
 				<link href="${styleUri}" rel="stylesheet">
 				
 				<title>Documentation View</title>

--- a/src/docsView.ts
+++ b/src/docsView.ts
@@ -6,6 +6,8 @@ enum UpdateMode {
 	Sticky = 'sticky',
 }
 
+const DEFAULT_FONTSIZE = 12
+
 export class DocsViewViewProvider implements vscode.WebviewViewProvider {
 
 	public static readonly viewType = 'docsView.documentation';
@@ -21,6 +23,7 @@ export class DocsViewViewProvider implements vscode.WebviewViewProvider {
 	private _loading?: { cts: vscode.CancellationTokenSource };
 
 	private _updateMode = UpdateMode.Live;
+	private _fontSize = DEFAULT_FONTSIZE;
 	private _pinned = false;
 
 	constructor(
@@ -40,6 +43,10 @@ export class DocsViewViewProvider implements vscode.WebviewViewProvider {
 
 		vscode.workspace.onDidChangeConfiguration(() => {
 			this.updateConfiguration();
+			if (this._view) {
+				// Explicitly set the updated HTML with new font size to trigger re-render
+				this._view.webview.html = this._getHtmlForWebview(this._view.webview);
+			}
 		}, null, this._disposables);
 
 		this.updateConfiguration();
@@ -132,6 +139,11 @@ export class DocsViewViewProvider implements vscode.WebviewViewProvider {
 
 				<link rel="stylesheet" href="${externalStyleUri}">
 				<link href="${styleUri}" rel="stylesheet">
+				<style>
+						body {
+								font-size: ${this._fontSize}px;
+						}
+				</style>
 				
 				<title>Documentation View</title>
 			</head>
@@ -234,6 +246,7 @@ export class DocsViewViewProvider implements vscode.WebviewViewProvider {
 	private updateConfiguration() {
 		const config = vscode.workspace.getConfiguration('docsView');
 		this._updateMode = config.get<UpdateMode>('documentationView.updateMode') || UpdateMode.Live;
+		this._fontSize = config.get<number>('documentationView.fontSize') || DEFAULT_FONTSIZE;
 	}
 }
 

--- a/src/markdown-it-texmath.d.ts
+++ b/src/markdown-it-texmath.d.ts
@@ -1,0 +1,4 @@
+declare module 'markdown-it-texmath' {
+  const texmath: any;
+  export default texmath;
+}

--- a/src/markdown-it-texmath.d.ts
+++ b/src/markdown-it-texmath.d.ts
@@ -2,3 +2,8 @@ declare module 'markdown-it-texmath' {
   const texmath: any;
   export default texmath;
 }
+
+declare module 'markdown-it-table-of-contents' {
+  const toc: any;
+  export default toc;
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,8 +1,10 @@
 import DOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
-import { Marked } from "marked";
 import * as vscode from 'vscode';
 import { CodeHighlighter } from './codeHighlighter';
+import markdownIt from 'markdown-it'
+import texmath from 'markdown-it-texmath'
+import katex from 'katex'
 
 export class Renderer {
 
@@ -40,14 +42,15 @@ export class Renderer {
 
 		const markdown = parts.join('\n---\n');
 
-		const highlight = await this._highlighter.getHighlighter(document);
-		const marked = new Marked({
-			renderer: {
-				code: (code: string, infostring: string | undefined, _escaped: boolean) => highlight(code, infostring ?? '')
-			}
+		const highlight_function = await this._highlighter.getHighlighter(document);
+		const md = markdownIt({
+			highlight: highlight_function
+		}).use(texmath, {
+			engine: katex,
+			delimiters: 'dollars',
 		});
 
-		const renderedMarkdown = await marked.parse(markdown, {});
+		const renderedMarkdown = md.render(markdown)
 		return this._purify.sanitize(renderedMarkdown, { USE_PROFILES: { html: true } });
 	}
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -4,7 +4,9 @@ import * as vscode from 'vscode';
 import { CodeHighlighter } from './codeHighlighter';
 import markdownIt from 'markdown-it'
 import texmath from 'markdown-it-texmath'
+import toc from 'markdown-it-table-of-contents'
 import katex from 'katex'
+// import {Marked} from 'marked'
 
 export class Renderer {
 
@@ -40,17 +42,31 @@ export class Renderer {
 			return '';
 		}
 
-		const markdown = parts.join('\n---\n');
+		const markdowna = parts.join('\n---\n');
+		const markdown = markdowna.replace(/\\/g, '');
+		console.log(markdowna)
 
 		const highlight_function = await this._highlighter.getHighlighter(document);
 		const md = markdownIt({
-			highlight: highlight_function
+			highlight: highlight_function,
+			html: true,
+			xhtmlOut: false,
+			breaks: false,
+			linkify: true,
+			typographer: false
 		}).use(texmath, {
 			engine: katex,
 			delimiters: 'dollars',
-		});
-
+		}).use(toc);
 		const renderedMarkdown = md.render(markdown)
+
+		/* const marked = new Marked({
+			renderer: {
+				code: (code: string, infostring: string | undefined, _escaped: boolean) => highlight_function(code, infostring ?? '')
+			}
+		});
+		const marked_markdown = await marked.parse(markdown, {}); */
+
 		return this._purify.sanitize(renderedMarkdown, { USE_PROFILES: { html: true } });
 	}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"rootDir": "src",
-		"allowSyntheticDefaultImports": true
+		"allowSyntheticDefaultImports": true,
+		"typeRoots": [
+			"./node_modules/@types",
+			"./src"
+		]
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
TLDR: Adds latex math support to the preview using markdown-it, markdown-it-texmath and katex (using katex css).

The default preview does not support math because of latency issues that the visual studio code team does not want on hover windows. Since this docs-view is not a hover, I think the latency is not an issue. One downside is, that we need to use a different markdown library than visual studio code uses for the preview, since marked does not support math. This may lead to unintentional differences between the hover view and the panel view.

Another unfortunate current state is that Pylance converts reST math (the standard for docstrings) to markdown code blocks. Therefore this will not be able to render reST math in the default state, because there is no way for this extension to differentiate between a normal code block and a code block that was converted from math. There are two workarounds: 1. Use the Jedi language server, which correctly returns reST math as markdown math. 2. Write your documentation in markdown, s.t. the language server does not alter the markup since it expects reST.

This is potentially a solution to [this vscode issue](https://github.com/microsoft/vscode/issues/168100), [this reddit thread](https://www.reddit.com/r/learnpython/comments/17kbx5t/how_to_better_document_math_equations_in_python/), [this stackoverflow question](https://stackoverflow.com/questions/61751393/view-latex-translation-of-documentation-when-hovering-on-function-definition) and even potentially for some [people currently using pycharm](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360010501280-PyCharm-Documentation-Improvements), so I think even with the caveats mentioned it is a valuable contribution for many scientific and mathematic programmers out there.

Example previewing `scipy.special.softmax`

![image](https://github.com/user-attachments/assets/4cc60a16-191a-4877-adf8-dd4138a8885b)
