### PR TITLE
fix highlight collapse in default themes

### DIFF
--- a/src/codeHighlighter.ts
+++ b/src/codeHighlighter.ts
@@ -1,16 +1,10 @@
 import json5 from 'json5';
 import * as shiki from 'shiki';
-import type { IShikiTheme, Theme } from 'shiki';
+import type { IShikiTheme } from 'shiki';
 import { Highlighter } from 'shiki';
 import * as vscode from 'vscode';
 
 declare const TextDecoder: any;
-
-// Default themes use `include` option that shiki doesn't support
-const defaultThemesMap = new Map<string, Theme>([
-	['Default Light+', 'light-plus'],
-	['Default Dark+', 'dark-plus'],
-]);
 
 function getCurrentThemePath(themeName: string): vscode.Uri | undefined {
 	for (const ext of vscode.extensions.all) {
@@ -87,9 +81,7 @@ export class CodeHighlighter {
 		let theme: string | IShikiTheme | undefined;
 
 		const currentThemeName = vscode.workspace.getConfiguration('workbench').get<string>('colorTheme');
-		if (currentThemeName && defaultThemesMap.has(currentThemeName)) {
-			theme = defaultThemesMap.get(currentThemeName);
-		} else if (currentThemeName) {
+		if (currentThemeName) {
 			const colorThemePath = getCurrentThemePath(currentThemeName);
 			if (colorThemePath) {
 				theme = await shiki.loadTheme(colorThemePath.fsPath);


### PR DESCRIPTION
# summary

| before | after |
|-|-|
|![image](https://github.com/user-attachments/assets/46b13eed-1f1f-48c3-b7b5-fb1491f879a6) | ![image](https://github.com/user-attachments/assets/f2b7f5be-e333-4fde-871c-d95350363bbc) |

# what I did

when using this extension with default theme (dark+), the highlighting didn't work.
The reason was, it was referring to a resource file which does not exist, and it happens when this extension is used with default dark+ theme.
It seems to be implemented by branching whether theme name is dark+ or light+. So I removed this branch and let shiki do all the thing.
It seems it's caused by version change of shiki. by migrating from 0.2.5 to 0.14, the folder structure seems to be changed.

# concerns

The comment says we need to handle default theme separately, because they use `include` option, which shiki does not support.
I looked the code carefully and I think it's okay to delete this special handling. But I'm not so confident.